### PR TITLE
Фиксы продакт-ревью

### DIFF
--- a/src/modes.ts
+++ b/src/modes.ts
@@ -108,7 +108,7 @@ export function createDefaultModes() {
         new TerraDrawRectangleMode(),
         new TerraDrawCircleMode(),
         new TerraDrawFreehandMode({
-            autoClose: true,
+            autoClose: false,
             minDistance: 10,
             pointerDistance: 10,
         }),

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -6,6 +6,7 @@ import { TerraDrawMapGlAdapter } from './adapter';
 import { createDefaultModes } from './modes';
 import { CONTROL_CONFIGS } from './l10n';
 import { Style, defaultStyle, makeTransparent } from './styles';
+import { FeatureId } from 'terra-draw/dist/extend';
 
 export type UiControlType =
     | 'select'
@@ -30,6 +31,7 @@ export interface MapDrawingOptions {
     container?: HTMLElement;
     controls?: UiControlType[];
     style?: Style;
+    stopByDoubleClick?: boolean;
 }
 
 const defaultControls: UiControlType[] = [
@@ -143,8 +145,10 @@ function createControlButton(label: string, icon: string, id: string): HTMLEleme
     iconElement.className = 'material-symbols-outlined';
     iconElement.textContent = icon;
     iconElement.style.cssText = `
-		font-size: 18px;
+		font-size: 24px;
 		line-height: 1;
+        user-select: none;
+        color: #4a4a4a;
 	`;
 
     button.appendChild(iconElement);
@@ -327,6 +331,7 @@ export function createTerraDrawWithUI({
     container = map.getContainer(),
     controls = defaultControls,
     style,
+    stopByDoubleClick = true,
 }: MapDrawingOptions): { draw: TerraDraw; cleanup: () => void } {
     const currentStyle = { ...defaultStyle, ...style };
 
@@ -431,18 +436,45 @@ export function createTerraDrawWithUI({
         }
     }
 
+    let selectedId: FeatureId | null = null;
+
     // Add clear handler
     if (controls.indexOf('clear') !== -1) {
         const clearButton = document.getElementById('clear');
         if (clearButton) {
             clearButton.addEventListener('click', () => {
-                if (!confirm('Are you sure want to clear all features?')) {
-                    return;
+                if (selectedId) {
+                    draw.removeFeatures([selectedId]);
+                } else {
+                    if (!confirm('Are you sure want to clear all features?')) {
+                        return;
+                    }
+                    draw.clear();
                 }
-                draw.clear();
             });
         }
     }
+
+    if (stopByDoubleClick) {
+        // HACK. To get doubleclick work like in other drawing libraries
+        // we need to temporarily switch to a render mode and restore
+        // after little timeout. So we avoid start drawing again in a second 
+        // click of doubleclick.
+        draw.on('finish', (_id, context) => {
+            const currentMode = context.mode;
+            draw.setMode('arbitrary');
+            setTimeout(() => {
+                draw.setMode(currentMode);
+            }, 500);
+        });
+    }
+
+    draw.on('select', (id) => {
+        selectedId = id;
+    });
+    draw.on('deselect', () => {
+        selectedId = null;
+    });
 
     // Start drawing
     draw.start();


### PR DESCRIPTION
Сделал правки по продакт ревью:
1. Теперь работа инструмент freehand работает так же как и остальные
2. Добавлен костылик, чтобы по doubleclick рисование прекращалось, а не начиналась рисоваться другая фича.
3. Чуть увеличил размер контролов.