### PR TITLE
Umd build

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,49 @@ load().then((mapgl) => {
 });
 ```
 
+Or directly in HTML via unpkg CDN
+
+```html
+<html>
+    <head>
+        <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" />
+        <link rel="stylesheet" type="text/css" href="https://unpkg.com/@2gis/mapgl-terra-draw@0.2.0/dist/mapgl-terra-draw.css" />
+        <script src="https://mapgl.2gis.com/api/js/v1"></script>
+        <script src="https://unpkg.com/terra-draw@1.0.0/dist/terra-draw.umd.js"></script>
+        <script src="https://unpkg.com/@2gis/mapgl-terra-draw/dist/mapgl-terra-draw.umd.cjs"></script>
+        <style>
+            html,
+            body,
+            #container {
+                margin: 0;
+                width: 100%;
+                height: 100%;
+                overflow: hidden;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="container"></div>
+        <script>
+            const map = new mapgl.Map('container', {
+                center: [55.31878, 25.23584],
+                zoom: 13,
+                key: 'bfd8bbca-8abf-11ea-b033-5fa57aae2de7',
+                enableTrackResize: true,
+            });
+
+            map.on('styleload', () => {
+                mapglTerraDraw.createTerraDrawWithUI({
+                    map,
+                    mapgl: mapgl,
+                    controls: ['color', 'select', 'point', 'polygon', 'circle', 'download', 'clear'],
+                });
+            });
+        </script>
+    </body>
+</html>
+```
+
 ## Advanced usage
 
 If advanced cases (use your custom drawing mode, customize a very flexible TerraDraw [selection behaviour](https://github.com/JamesLMilner/terra-draw/blob/main/guides/4.MODES.md#selection-mode), design a fancy UI, e.g.) you can use `TerraDrawMapGlAdapter` class directly.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@2gis/mapgl-terra-draw",
-  "version": "0.2.1",
+  "version": "0.3.0-umd.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@2gis/mapgl-terra-draw",
-      "version": "0.2.1",
+      "version": "0.3.0-umd.0",
       "license": "MIT",
       "dependencies": {
         "@2gis/mapgl": "^1.61.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@2gis/mapgl-terra-draw",
   "description": "TerraDraw adapter for MapGL JS API",
-  "version": "0.2.1",
+  "version": "0.3.0-umd.0",
   "type": "module",
   "main": "dist/mapgl-terra-draw.cjs",
   "module": "dist/mapgl-terra-draw.js",

--- a/vite.config.lib.js
+++ b/vite.config.lib.js
@@ -8,7 +8,8 @@ export default defineConfig({
   build: {
     lib: {
       entry: resolve(__dirname, 'src/index.ts'),
-      formats: ['es', 'cjs']
+      name: 'mapglTerraDraw',
+      formats: ['es', 'umd', 'cjs']
     },
     rollupOptions: {
       external: ['terra-draw', '@2gis/mapgl'],


### PR DESCRIPTION
Добавил umd-билд для плагина. 

umd-билд нужен, чтобы использовать его напрямую из HTML, для демок в codepen ([например](https://codepen.io/itanka9/pen/qEOxeWL?editors=0010)).

Использование umd-билда описал в README